### PR TITLE
Gmail Web-based clients cutoff fix

### DIFF
--- a/salted-responsive-email-template.html
+++ b/salted-responsive-email-template.html
@@ -129,7 +129,7 @@
 <body style="margin: 0; padding: 0;">
 
 <!-- HEADER -->
-<table border="0" cellpadding="0" cellspacing="0" width="100%" style="table-layout: fixed;">
+<table border="0" cellpadding="0" cellspacing="0" width="100%">
     <tr>
         <td bgcolor="#ffffff">
             <div align="center" style="padding: 0px 15px 0px 15px;">
@@ -158,7 +158,7 @@
 </table>
 
 <!-- ONE COLUMN SECTION -->
-<table border="0" cellpadding="0" cellspacing="0" width="100%" style="table-layout: fixed;">
+<table border="0" cellpadding="0" cellspacing="0" width="100%">
     <tr>
         <td bgcolor="#ffffff" align="center" style="padding: 70px 15px 70px 15px;" class="section-padding">
             <table border="0" cellpadding="0" cellspacing="0" width="500" class="responsive-table">
@@ -223,7 +223,7 @@
 </table>
 
 <!-- ONE COLUMN W/ BOTTOM IMAGE SECTION -->
-<table border="0" cellpadding="0" cellspacing="0" width="100%" style="table-layout: fixed;">
+<table border="0" cellpadding="0" cellspacing="0" width="100%">
     <tr>
         <td bgcolor="#f8f8f8" align="center" style="padding: 70px 15px 0 15px;" class="section-padding-bottom-image">
             <table border="0" cellpadding="0" cellspacing="0" width="500" class="responsive-table">
@@ -280,7 +280,7 @@
 </table>
 
 <!-- TWO COLUMN SECTION -->
-<table border="0" cellpadding="0" cellspacing="0" width="100%" style="table-layout: fixed;">
+<table border="0" cellpadding="0" cellspacing="0" width="100%">
     <tr>
         <td bgcolor="#ffffff" align="center" style="padding: 70px 15px 70px 15px;" class="section-padding">
             <table border="0" cellpadding="0" cellspacing="0" width="500" class="responsive-table">
@@ -398,7 +398,7 @@
 
 
 <!-- COMPACT ARTICLE SECTION -->
-<table border="0" cellpadding="0" cellspacing="0" width="100%" style="table-layout: fixed;">
+<table border="0" cellpadding="0" cellspacing="0" width="100%">
     <tr>
         <td bgcolor="#f8f8f8" align="center" style="padding: 70px 15px 70px 15px;" class="section-padding">
             <table border="0" cellpadding="0" cellspacing="0" width="500" style="padding:0 0 20px 0;" class="responsive-table">
@@ -529,7 +529,7 @@
 </table>
 
 <!-- FOOTER -->
-<table border="0" cellpadding="0" cellspacing="0" width="100%" style="table-layout: fixed;">
+<table border="0" cellpadding="0" cellspacing="0" width="100%">
     <tr>
         <td bgcolor="#ffffff" align="center">
             <table width="100%" border="0" cellspacing="0" cellpadding="0" align="center">


### PR DESCRIPTION
See, Issue #1. Reverted updates made for Yahoo Fix. Code updates made for Yahoo fix breaks Gmail Web-based clients. The issue mentions IE, but Chrome and FF are also affected. Yahoo Web-based clients appear to look great as well - maybe Yahoo fixed their issue?

This issue was first noticed about a month ago. Here is the Litmus test validating the reported issue. Click on Gmail (Explorer) under Web-based Clients:
https://litmus.com/pub/5d1bf75/screenshots

Validate the entire right-half of the screen is cutoff. Here is the Litmus test validating the fix:
https://litmus.com/pub/4b69fef/screenshots

Validate the email is rendering as expected. Here is a production use of Salted where this fix is implemented as well:
https://litmus.com/pub/c1edff7/screenshots

Validate all Web-based clients render as expected.

Thanks for developing this responsive email template! If there is such a thing as Developer Experience (DX), I would rate using salted very high. Salted continues to be a pleasure to use.